### PR TITLE
Update Kubernetes authentication

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,75 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version = "2.24.0"
+  hashes = [
+    "h1:sFk402FWKKqHvSLhVxQUnn9+DiUL6kmzghs2t397R1U=",
+    "zh:172cedc19e725327e7a22ee98e69b66b1aa03ff3edbf3a8aa392d6959cfbb4cf",
+    "zh:35bde5dfc975215ca23e7785885ec60d691395d15fcbdac568791298c0977543",
+    "zh:3a560866ada6c6f7e54bc073008a42305cb05eb21ed2fed150d6016f098c1b5e",
+    "zh:4b9eac07796743dd922715067640ba53afd9ff05760543d1d71330e63ac1396f",
+    "zh:7c28b13778b04ccf07299e5e359c1a118a6d85b901604a1291c3d00fadd65042",
+    "zh:9448973df85cb83f757043b28c08b82f91f76fe35d3bfbd41c08fa322a47c82a",
+    "zh:9a79b522d8fbb97ea789a663777abff2c56a34337666aed0b7341f42633d9751",
+    "zh:a97f1c13f7b49a40ea53cb91b4e774bd7c2e0da3aa6583a9d099a94583338173",
+    "zh:b75cdb69b85605682d0fc5f35b8571b4a89a4881f0891c37236b43d3bc700796",
+    "zh:bbdff4c9ca2f1ee5051aba11541235e0d3b37d72a46bee487f984fba1145d064",
+    "zh:ef5bb5ecf051f1246152e4f04dc0b5b7a72230a59ed3e6b020472adf1de2ae01",
+    "zh:fef45da5b60652de9c4f34b320505d5c610898763abf4b7db06f6e3436f38829",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.34.0"
+  hashes = [
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
+    "zh:003272229bd19bb63d6e77bc3d684268c417a151dfaee01c40b40e21cdd8bb0f",
+    "zh:103cacc1f3d97dfb7e9dd1e1905b075f92d9bd8aed434f811e8111788b648a57",
+    "zh:63a43c6e5fb2e5ad59ea068bede5c6bb54358affd32163d72785473a15440427",
+    "zh:6648af39a318c85eb336e2fb3ec1a01c5ffe8d75cc51686c37e892dd6f6a8974",
+    "zh:71ac8f6d5d61e5dee90099fd4fc1bb5bcd8ccb674eb6e7cd58d20757f7cecd12",
+    "zh:73baae4aa5bc0af12917e3bb17e1086050d25cdf7ba604f7fc422653c99f884c",
+    "zh:7d920ac05c45e77c59c49e0dd0cb010d64202c5a2fdfde6d9efe3dc61e396c97",
+    "zh:8a495e49f8fcbe276a74911f9ca48381533686ff71a9d4f7027bb9109769b639",
+    "zh:8ab9769581dfc1675c645e33e7ab8fea6ad1acc9e232eeda823070447e5ecaf1",
+    "zh:a170ecc560d49c251f4bebb6d6a82ff3637ae16a0f779a53489d4a64ddd1ee6a",
+    "zh:d9178201057b62666691ec206d1fbe09965bcfea532085b4e31f46073bf5898f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.0.3"
+  hashes = [
+    "h1:FRSVqY+1/AUO/j/lVxHHsLudfSA9gDc7Dsu+YxcJSEY=",
+    "zh:154e0aa489e474e2eeb3de94be7666133faf6fd950712a640425b2bf3a81ee95",
+    "zh:16a2be6c4b61d0c5205c63816148c7ab0c8f56a75c05e8d897fa4d5cac0c029a",
+    "zh:189e47bc723f8c29bcfe2c1638d43b8148f614ea86e642f4b50b2acb4b760224",
+    "zh:3763901d3630213002cb8c70bb24c628cd29738ff6591585250ea8636264abd6",
+    "zh:4822f85e4700ea049384523d98de0ef7d83549844b13e94bbd544cec05557a9a",
+    "zh:62c5b87b09e0051bab0b712e3ad465fd53e66f9619dbe76ee23519d1087d8a05",
+    "zh:a0a6a842b11190dd1841e98bbb74961074e7ffb95984be5cc392df9f532d803e",
+    "zh:beac4e6806e77447e1018f3404a5fbf782d20d82a0d9b4a31e9bfc7d2bbecab6",
+    "zh:e1bbaa09bf4f4a91ec7606f84d2e0200a02e7b24d045e8b5daebd87d7a75b7ce",
+    "zh:ed1e05c50212d4f57435ccdd68cfb98d8395927c316df76d1dd6509566d3aeaa",
+    "zh:fdc687e16a964bb652ddb670f6832fdead25235eca551796cfed70ec07d94931",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.0.3"
+  hashes = [
+    "h1:u3QLP3ca1ZYtdx4t9LrNLzAA3HY/GAT06hznb2pqNC4=",
+    "zh:3847733636ed2aca8694227ee6936fecc6cec9573818ecf64acc2a01a4fb3ae4",
+    "zh:44d3e88227174d2e51e0273e732e54bb5f5d8150bbf1adecd2be198c857a0264",
+    "zh:7c147baeac90ddc71b8c106409dc2e06e6fe04448a0ae36c7ef919b8b27c8d5f",
+    "zh:832ebd1eec844fdc00ecbc5e694ecf532d0c7a94f2a1697ea0c7bc159696d529",
+    "zh:920c8f64925d346a0621aadede6a4ac1bbe650f16c2074a0a6b5eeb7a5c35cf7",
+    "zh:a26906cd3aeb28f402972154dbb3ae1ac6d739ce3e4b00906c9d4b1e263d5a56",
+    "zh:a7b3cbd06684f843f700ee9281c583cc593e00e3acc2c0a34f6dad4e35a1ec60",
+    "zh:b43c05ade832995a09c40a1c2f080586f38de1edc8c46be2e6f90b96c58a2482",
+    "zh:cba2a979889e79ffe48bb5ea7e63f88c344ae2cd7a341afb77b3c8d417658d6c",
+    "zh:e00b2ec7357a58a435a69146da3c256178caab83a6574969d4660b69996c7955",
+    "zh:f95f179f68aed39b8d73d7914176baf74509d74f90a1e3a600a8eb4461f8f0a3",
+  ]
+}

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -20,11 +20,18 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 provider "kubernetes" {
-  load_config_file = "false"
-  host             = data.aws_eks_cluster.cluster.endpoint
-  token            = data.aws_eks_cluster_auth.cluster.token
-
+  host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      data.aws_eks_cluster.cluster.name
+    ]
+  }
 }
 
 resource "kubernetes_namespace" "beacon" {

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -93,5 +93,5 @@ resource "kubernetes_service" "beacon" {
 }
 
 output "beacon_endpoint" {
-  value = "${kubernetes_service.beacon.load_balancer_ingress[0].hostname}:8080"
+  value = "${kubernetes_service.beacon.status[0].load_balancer[0].ingress[0].hostname}:8080"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,20 +2,24 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 2.16.0"
+      version = "~> 2.24.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 1.3.2"
+      version = "~> 2.0.3"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.13.3"
+      version = "~> 2.0.3"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.14"
+      version = "~> 3.34"
     }
   }
-  required_version = "~> 0.13.5"
+  required_version = "~> 0.13"
+}
+
+provider "aws" {
+  region = "us-east-2"
 }


### PR DESCRIPTION
- Update the kubernetes provider to use token-based auth.
- Update providers to latest versions
- Explicitly set AWS region to match the one from the companion EKS tutorial ("us-east-2")
- Update terraform `required_version` to work with, but not require, Terraform 0.14.